### PR TITLE
URL Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: java
 jdk:
   - oraclejdk8
 install:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz
+  - wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz
   - tar zxf mongodb-linux-x86_64-${MONGODB}.tgz
   - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --version
   - ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -U


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://fastdl.mongodb.org/linux/mongodb-linux-x86_64- (403) with 1 occurrences migrated to:  
  https://fastdl.mongodb.org/linux/mongodb-linux-x86_64- ([https](https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-) result 403).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:8080/master/gateway-prod.properties with 1 occurrences